### PR TITLE
feat: Add a the original index of the item in the parameters

### DIFF
--- a/.github/workflows/deploy_pub_dev.yml
+++ b/.github/workflows/deploy_pub_dev.yml
@@ -13,7 +13,7 @@ jobs:
       - name: 'Checkout'
         uses: actions/checkout@v2
       - name: '>> Dart package <<'
-        uses: k-paxian/dart-package-publisher@master
+        uses: k-paxian/dart-package-publisher@1.5.1
         with:
           accessToken: ${{ secrets.OAUTH_ACCESS_TOKEN }}
           refreshToken: ${{ secrets.OAUTH_REFRESH_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,14 @@ See [documentation](https://github.com/quentin7b/flutter_grouped_listview)
 ## 1.0.1
 
 * Fixes an issue that makes horizontal lists and scroll lead to Unbounded height
+
+## 2.0.0
+
+* Added a new argument in the builders `itemsBuilder` and `customBuilder` no longer takes `List<I>` as parameter but a `List<IndexedItem<I>>`.
+* `gridItemBuilder` in `GroupedListView.grid` and `listItemBuilder` in `GroupedListView.list()` are taking a new parameter, `int itemIndexInOriginalList` which is, as it says, the index of the item in the original given list.
+
+This is a breaking change, as your code needs to be updated to takes this new parameter in account.
+
+This fills a [requirement asked in the project](https://github.com/quentin7b/flutter_grouped_listview/issues/5) 
+
+> This would be necessary to create a "scroll to header" function and is available in most List/GridView objects and other grouped list packages.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ GroupedListView.list(
         padding: const EdgeInsets.all(16),
     ),
     listItemBuilder:
-        (context, int countInGroup, int itemIndexInGroup, int item) =>
+        (context, int countInGroup, int itemIndexInGroup, int item, int itemIndexInOriginalList) =>
             Container(
         child: Text(item.toRadixString(10), textAlign: TextAlign.center),
         padding: const EdgeInsets.all(8),
@@ -114,7 +114,7 @@ GroupedListView.grid(
         padding: const EdgeInsets.all(16),
     ),
     gridItemBuilder:
-        (context, int countInGroup, int itemIndexInGroup, int item) =>
+        (context, int countInGroup, int itemIndexInGroup, int item, int itemIndexInOriginalList) =>
             Container(
         child: Text(item.toRadixString(10), textAlign: TextAlign.center),
         padding: const EdgeInsets.all(8),
@@ -138,12 +138,12 @@ GroupedListView(
         ),
         padding: const EdgeInsets.all(16),
     ),
-    itemsBuilder: (context, List<int> items) => ListView.builder(
+    itemsBuilder: (context, List<IndexedItem<int>> items) => ListView.builder(
         itemCount: items.length,
         shrinkWrap: true,
         physics: const NeverScrollableScrollPhysics(),
         itemBuilder: (context, int index) => Container(
-            child: Text(items[index].toRadixString(10),
+            child: Text(items[index].item.toRadixString(10),
                 textAlign: TextAlign.center),
             padding: const EdgeInsets.all(8),
         ),
@@ -162,7 +162,7 @@ No worries, you can use a specific **constructor** to do so.
 ```dart
 GroupedListView(
     items: List<int>.generate(100, (index) => index + 1),
-    customBuilder: (context, bool isEvenHeader, List<int> items) => StickyHeader(
+    customBuilder: (context, bool isEvenHeader, List<<IndexedItem<int>> items) => StickyHeader(
         header: Container(
         color: Colors.amber,
         child: Text(
@@ -175,7 +175,7 @@ GroupedListView(
             shrinkWrap: true,
             physics: const NeverScrollableScrollPhysics(),
             itemBuilder: (context, int index) => Container(
-                child: Text(items[index].toRadixString(10),
+                child: Text(items[index].item.toRadixString(10),
                     textAlign: TextAlign.center),
                 padding: const EdgeInsets.all(8),
             ),
@@ -185,7 +185,7 @@ GroupedListView(
 )
 ```
 
-> Using the `GroupedListView()` with a `customBuilder` helps you manage your UI with what you want the customBuilder being a Function that gives you a `BuildContext`, a `H` (your header type) and a `List<T>`
+> Using the `GroupedListView()` with a `customBuilder` helps you manage your UI with what you want the customBuilder being a Function that gives you a `BuildContext`, a `H` (your header type) and a `List<IndexedItem<T>>`
 
 
 ## Additional information

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.7.0'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -79,7 +79,7 @@ class CustomPage extends StatelessWidget {
             padding: const EdgeInsets.all(16),
           );
         },
-        itemsBuilder: (context, List<int> items) {
+        itemsBuilder: (context, List<IndexedItem<int>> items) {
           return ListView.builder(
               itemCount: items.length,
               shrinkWrap: true,
@@ -92,7 +92,7 @@ class CustomPage extends StatelessWidget {
                     ((128 / items.length) * index).toInt() + 127,
                     ((128 / items.length) * index).toInt() + 127,
                   ),
-                  child: Text(items[index].toRadixString(10),
+                  child: Text(items[index].item.toRadixString(10),
                       textAlign: TextAlign.center),
                   padding: const EdgeInsets.all(8),
                 );
@@ -125,7 +125,7 @@ class ListPage extends StatelessWidget {
           );
         },
         listItemBuilder:
-            (context, int countInGroup, int itemIndexInGroup, int item) =>
+            (context, int countInGroup, int itemIndexInGroup, int item, _) =>
                 Container(
           color: Color.fromARGB(
             255,
@@ -162,7 +162,7 @@ class GridPage extends StatelessWidget {
           );
         },
         gridItemBuilder:
-            (context, int countInGroup, int itemIndexInGroup, int item) =>
+            (context, int countInGroup, int itemIndexInGroup, int item, _) =>
                 Container(
           color: Color.fromARGB(
             255,
@@ -188,9 +188,10 @@ class StickyPage extends StatelessWidget {
     return Scaffold(
       appBar:
           AppBar(title: const Text('Custom GroupedListView with StickyHeader')),
-      body: GroupedListView(
+      body: GroupedListView<bool, int>(
         items: List<int>.generate(100, (index) => index + 1),
-        customBuilder: (context, bool isEvenHeader, List<int> items) {
+        customBuilder:
+            (context, bool isEvenHeader, List<IndexedItem<int>> items) {
           return StickyHeader(
               header: Container(
                 color: Colors.amber,
@@ -212,7 +213,7 @@ class StickyPage extends StatelessWidget {
                         ((128 / items.length) * index).toInt() + 127,
                         ((128 / items.length) * index).toInt() + 127,
                       ),
-                      child: Text(items[index].toRadixString(10),
+                      child: Text(items[index].item.toRadixString(10),
                           textAlign: TextAlign.center),
                       padding: const EdgeInsets.all(8),
                     );
@@ -241,7 +242,7 @@ class HorizontalPage extends StatelessWidget {
         itemGrouper: (int i) => i.isEven,
         headerBuilder: (context, bool isEven) => Text(isEven ? 'Even' : 'Odd'),
         listItemBuilder:
-            (context, int countInGroup, int itemIndexInGroup, int item) =>
+            (context, int countInGroup, int itemIndexInGroup, int item, _) =>
                 Container(
           color: Color.fromARGB(
             255,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,28 +21,21 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -56,7 +49,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -87,21 +80,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   simple_grouped_listview:
     dependency: "direct main"
     description:
@@ -120,7 +120,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -148,35 +148,28 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.15.1 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=1.17.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,8 +6,8 @@ homepage: https://github.com/quentin7b/flutter_grouped_listview
 repository: https://github.com/quentin7b/flutter_grouped_listview
 issue_tracker: https://github.com/quentin7b/flutter_grouped_listview/issues
 
-version: 1.0.1
-publish_to: 
+version: 2.0.0
+publish_to: https://pub.dev/
 
 environment:
   sdk: ">=2.15.1 <3.0.0"


### PR DESCRIPTION
* Added a new argument in the builders `itemsBuilder` and `customBuilder` no longer takes `List<I>` as parameter but a `List<IndexedItem<I>>`.
* `gridItemBuilder` in `GroupedListView.grid` and `listItemBuilder` in `GroupedListView.list()` are taking a new parameter, `int itemIndexInOriginalList` which is, as it says, the index of the item in the original given list.

See #5 